### PR TITLE
Extend Authentication Modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 It is a continuation of https://github.com/damico/java-socks-proxy-server.
 
-```
+```xml
 <dependency>
   <groupId>com.github.bbottema</groupId>
   <artifactId>java-socks-proxy-server</artifactId>
@@ -18,27 +18,36 @@ It is a continuation of https://github.com/damico/java-socks-proxy-server.
 
 ## Usage:
 
-```
-SocksServer socksServer = new SocksServer();
-
-socksServer.start(100); // start serving clients on port 100
-socksServer.start(200); // start serving clients on port 200
-socksServer.start(300, myCustomServerSocketFactory); // eg. SSL on port 300
-
-socksServer.stop(); // stops server on all ports
+```java
+// start serving clients on port 1234
+SocksServer server = new SocksServer(1234).start();
 ```
 
-For use in junit tests:
+Or you can supply your own `ServerSocketFactory`:
 
+```java
+// e.g. SSL on port 7132
+SocksServer server = new SocksServer(1234, myCustomServerFactory).start();
 ```
-	@ClassRule
-	public static final SockServerRule sockServerRule = new SockServerRule(PROXY_SERVER_PORT);
-	
-	// or
-	
-	@ClassRule
-	public static final SockServerRule sockServerRule = new SockServerRule(PROXY_SERVER_PORT, myServerSocketFactory);
+
+> By default, library uses `NO_AUTH` authentication mode
+
+### Username and Password Authentication
+
+If you want to authenticate the clients, before proxying, you can set a `UsernamePasswordAuthenticator`, library supports standard Username/Password protocol.
+
+```java
+    new SocksServer(1234)
+        .setAuthenticator(new UsernamePasswordAuthenticator(false) {
+          @Override
+          public boolean validate(String username, String password) {
+            // validate credentials here, e.g. check your local database
+            return username.equals("mysecureusername") && password.equals("mysecurepassword");
+          }
+        }).start();
 ```
+
+> Supply a `true` value to constructor `UsernamePasswordAuthenticator()`, if you also want to prefer `NO_AUTH` mode over Username and password.
 
 And that's it!
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ It is a continuation of https://github.com/damico/java-socks-proxy-server.
 ```java
 // start serving clients on port 1234
 SocksServer server = new SocksServer(1234).start();
+...
+server.stop(); // stop serving any new proxy requests
 ```
 
 Or you can supply your own `ServerSocketFactory`:

--- a/src/main/java/org/bbottema/javasocksproxyserver/AuthConstants.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/AuthConstants.java
@@ -1,0 +1,13 @@
+package org.bbottema.javasocksproxyserver;
+
+public interface AuthConstants {
+  byte AUTH_VERSION = 0x01;
+  byte[] AUTH_USER_PASS_SUCCESS = new byte[] { AUTH_VERSION, 0x00 };
+  // 0x00 denotes success, any other value denotes failure
+  byte[] AUTH_USER_PASS_FAILED = new byte[] { AUTH_VERSION, 0x01 };
+
+  byte TYPE_NO_AUTH = 0x00;
+  byte TYPE_USER_PASS_AUTH = 0x02;
+
+  byte NONE_ACCEPTED = (byte) 0xff;
+}

--- a/src/main/java/org/bbottema/javasocksproxyserver/AuthConstants.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/AuthConstants.java
@@ -1,13 +1,13 @@
 package org.bbottema.javasocksproxyserver;
 
 public interface AuthConstants {
-  byte AUTH_VERSION = 0x01;
-  byte[] AUTH_USER_PASS_SUCCESS = new byte[] { AUTH_VERSION, 0x00 };
-  // 0x00 denotes success, any other value denotes failure
-  byte[] AUTH_USER_PASS_FAILED = new byte[] { AUTH_VERSION, 0x01 };
+    byte AUTH_VERSION = 0x01;
+    byte[] AUTH_USER_PASS_SUCCESS = new byte[]{AUTH_VERSION, 0x00};
+    // 0x00 denotes success, any other value denotes failure
+    byte[] AUTH_USER_PASS_FAILED = new byte[]{AUTH_VERSION, 0x01};
 
-  byte TYPE_NO_AUTH = 0x00;
-  byte TYPE_USER_PASS_AUTH = 0x02;
+    byte TYPE_NO_AUTH = 0x00;
+    byte TYPE_USER_PASS_AUTH = 0x02;
 
-  byte NONE_ACCEPTED = (byte) 0xff;
+    byte NONE_ACCEPTED = (byte) 0xff;
 }

--- a/src/main/java/org/bbottema/javasocksproxyserver/ProxyHandler.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/ProxyHandler.java
@@ -1,5 +1,7 @@
 package org.bbottema.javasocksproxyserver;
 
+import org.bbottema.javasocksproxyserver.auth.Authenticator;
+import org.bbottema.javasocksproxyserver.auth.DefaultAuthenticator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,13 +26,20 @@ public class ProxyHandler implements Runnable {
 	private Object m_lock;
 	private Socks4Impl comm = null;
 
+	final Authenticator authenticator;
+
 	Socket m_ClientSocket;
 	Socket m_ServerSocket = null;
 	byte[] m_Buffer = new byte[SocksConstants.DEFAULT_BUF_SIZE];
 
 	public ProxyHandler(Socket clientSocket) {
+		this(clientSocket, new DefaultAuthenticator());
+	}
+
+	public ProxyHandler(Socket clientSocket, Authenticator authenticator) {
 		m_lock = this;
 		m_ClientSocket = clientSocket;
+		this.authenticator = authenticator;
 		try {
 			m_ClientSocket.setSoTimeout(SocksConstants.DEFAULT_PROXY_TIMEOUT);
 		} catch (SocketException e) {
@@ -179,6 +188,7 @@ public class ProxyHandler implements Runnable {
 			LOGGER.debug("Accepted SOCKS " + SOCKS_Version + " Request.");
 
 			comm.authenticate(SOCKS_Version);
+			comm.clientAuthResponse();
 			comm.getClientCommand();
 
 			switch (comm.socksCommand) {

--- a/src/main/java/org/bbottema/javasocksproxyserver/Socks4Impl.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/Socks4Impl.java
@@ -116,6 +116,11 @@ public class Socks4Impl {
 		SOCKS_Version = SOCKS_Ver;
 	}
 
+
+	public void clientAuthResponse() throws Exception {
+		// Socks5Impl must implement this
+	}
+
 	public void getClientCommand() throws Exception {
 		// Version was get in method Authenticate()
 		socksCommand = getByte();

--- a/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
@@ -25,9 +25,11 @@ public class Socks5Impl extends Socks4Impl {
 			16  //'04' IP v6 - 16bytes
 	};
 	private static final Logger LOGGER = LoggerFactory.getLogger(Socks5Impl.class);
-	private static final byte[] SRE_REFUSE = {(byte) 0x05, (byte) 0xFF};
-	private static final byte[] SRE_ACCEPT = {(byte) 0x05, (byte) 0x00};
+
 	private static final int MAX_ADDR_LEN = 255;
+
+	private byte acceptedAuthType = 0x00;
+
 	private byte ADDRESS_TYPE;
 	private DatagramSocket DGSocket = null;
 	private DatagramPacket DGPack = null;
@@ -94,32 +96,62 @@ public class Socks5Impl extends Socks4Impl {
 		super.authenticate(SOCKS_Ver); // Sets SOCKS Version...
 
 		if (SOCKS_Version == SocksConstants.SOCKS5_Version) {
-			if (!checkAuthentication()) {// It reads whole Cli Request
-				refuseAuthentication("SOCKS 5 - Not Supported Authentication!");
-				throw new Exception("SOCKS 5 - Not Supported Authentication.");
-			}
-			acceptAuthentication();
-		}// if( SOCKS_Version...
-		else {
-			refuseAuthentication("Incorrect SOCKS version : " + SOCKS_Version);
+			byte[] authModes = getAuthenticationModes();
+			acceptedAuthType = m_Parent.authenticator.accept(authModes);
+			sendAuthResponse(acceptedAuthType);
+		} else {
+			sendAuthResponse(AuthConstants.NONE_ACCEPTED);
+      LOGGER.debug("SOCKS 5 - Refuse Authentication: Incorrect SOCKS version: {}", SOCKS_Version);
 			throw new Exception("Not Supported SOCKS Version -'" +
 					SOCKS_Version + "'");
 		}
 	}
 
-	public void refuseAuthentication(String msg) {
-		LOGGER.debug("SOCKS 5 - Refuse Authentication: '" + msg + "'");
-		m_Parent.sendToClient(SRE_REFUSE);
+	@Override
+	public void clientAuthResponse() throws Exception {
+		if (acceptedAuthType != AuthConstants.TYPE_USER_PASS_AUTH) {
+			return;
+		}
+    byte version = getByte();
+    if (version != AuthConstants.AUTH_VERSION) {
+      m_Parent.sendToClient(AuthConstants.AUTH_USER_PASS_FAILED);
+      throw new Exception("Not supported SOCKS Username Password Version - '" + version + "'");
+    }
+    byte[] username = readByteString();
+    byte[] password = readByteString();
+
+    boolean credentialsAccepted = m_Parent.authenticator.validate(username, password);
+
+    m_Parent.sendToClient(credentialsAccepted ? AuthConstants.AUTH_USER_PASS_SUCCESS : AuthConstants.AUTH_USER_PASS_FAILED);
+    m_Parent.sendToClient(new byte[] {0x01, 0x00});
+  }
+
+	public byte[] readByteString() {
+		byte length = getByte();
+		byte[] bytes = new byte[length];
+
+		for (int i = 0; i < length; i++) {
+			bytes[i] = getByte();
+		}
+		return bytes;
+	}
+
+	private byte[] getAuthenticationModes() {
+		byte numberOfAuthModesAvailable = getByte();
+		byte[] auths = new byte[numberOfAuthModesAvailable];
+		for (byte i = 0; i < numberOfAuthModesAvailable; i++) {
+			auths[i] = getByte();
+		}
+		return auths;
 	}
 
 
-	public void acceptAuthentication() {
-		LOGGER.debug("SOCKS 5 - Accepts Auth. method 'NO_AUTH'");
-		byte[] tSRE_Accept = SRE_ACCEPT;
-		tSRE_Accept[0] = SOCKS_Version;
-		m_Parent.sendToClient(tSRE_Accept);
+	private void sendAuthResponse(byte result) {
+		byte[] authResponse = new byte[2];
+		authResponse[0] = SOCKS_Version;
+		authResponse[1] = result;
+		m_Parent.sendToClient(authResponse);
 	}
-
 
 	public boolean checkAuthentication() {
 		final byte Methods_Num = getByte();

--- a/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
@@ -98,10 +98,11 @@ public class Socks5Impl extends Socks4Impl {
 		if (SOCKS_Version == SocksConstants.SOCKS5_Version) {
 			byte[] authModes = getAuthenticationModes();
 			acceptedAuthType = m_Parent.authenticator.accept(authModes);
+			System.out.println("Accepted auth type " + acceptedAuthType);
 			sendAuthResponse(acceptedAuthType);
 		} else {
 			sendAuthResponse(AuthConstants.NONE_ACCEPTED);
-      		LOGGER.debug("SOCKS 5 - Refuse Authentication: Incorrect SOCKS version: {}", SOCKS_Version);
+			LOGGER.debug("SOCKS 5 - Refuse Authentication: Incorrect SOCKS version: {}", SOCKS_Version);
 			throw new Exception("Not Supported SOCKS Version -'" +
 					SOCKS_Version + "'");
 		}
@@ -121,9 +122,8 @@ public class Socks5Impl extends Socks4Impl {
     	byte[] password = readByteString();
 
     	boolean credentialsAccepted = m_Parent.authenticator.validate(username, password);
-
+		System.out.println("Credentials accepted: " + credentialsAccepted);
     	m_Parent.sendToClient(credentialsAccepted ? AuthConstants.AUTH_USER_PASS_SUCCESS : AuthConstants.AUTH_USER_PASS_FAILED);
-    	m_Parent.sendToClient(new byte[] {0x01, 0x00});
    }
 
 	public byte[] readByteString() {

--- a/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
@@ -153,17 +153,6 @@ public class Socks5Impl extends Socks4Impl {
 		m_Parent.sendToClient(authResponse);
 	}
 
-	public boolean checkAuthentication() {
-		final byte Methods_Num = getByte();
-		final StringBuilder Methods = new StringBuilder();
-
-		for (int i = 0; i < Methods_Num; i++) {
-			Methods.append(",-").append(getByte()).append('-');
-		}
-
-		return ((Methods.indexOf("-0-") != -1) || (Methods.indexOf("-00-") != -1));
-	}
-
 	public void getClientCommand() throws Exception {
 		SOCKS_Version = getByte();
 		socksCommand = getByte();

--- a/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
@@ -101,7 +101,7 @@ public class Socks5Impl extends Socks4Impl {
 			sendAuthResponse(acceptedAuthType);
 		} else {
 			sendAuthResponse(AuthConstants.NONE_ACCEPTED);
-      LOGGER.debug("SOCKS 5 - Refuse Authentication: Incorrect SOCKS version: {}", SOCKS_Version);
+      		LOGGER.debug("SOCKS 5 - Refuse Authentication: Incorrect SOCKS version: {}", SOCKS_Version);
 			throw new Exception("Not Supported SOCKS Version -'" +
 					SOCKS_Version + "'");
 		}
@@ -112,19 +112,19 @@ public class Socks5Impl extends Socks4Impl {
 		if (acceptedAuthType != AuthConstants.TYPE_USER_PASS_AUTH) {
 			return;
 		}
-    byte version = getByte();
-    if (version != AuthConstants.AUTH_VERSION) {
-      m_Parent.sendToClient(AuthConstants.AUTH_USER_PASS_FAILED);
-      throw new Exception("Not supported SOCKS Username Password Version - '" + version + "'");
-    }
-    byte[] username = readByteString();
-    byte[] password = readByteString();
+    	byte version = getByte();
+    	if (version != AuthConstants.AUTH_VERSION) {
+      		m_Parent.sendToClient(AuthConstants.AUTH_USER_PASS_FAILED);
+      		throw new Exception("Not supported SOCKS Username Password Version - '" + version + "'");
+    	}
+    	byte[] username = readByteString();
+    	byte[] password = readByteString();
 
-    boolean credentialsAccepted = m_Parent.authenticator.validate(username, password);
+    	boolean credentialsAccepted = m_Parent.authenticator.validate(username, password);
 
-    m_Parent.sendToClient(credentialsAccepted ? AuthConstants.AUTH_USER_PASS_SUCCESS : AuthConstants.AUTH_USER_PASS_FAILED);
-    m_Parent.sendToClient(new byte[] {0x01, 0x00});
-  }
+    	m_Parent.sendToClient(credentialsAccepted ? AuthConstants.AUTH_USER_PASS_SUCCESS : AuthConstants.AUTH_USER_PASS_FAILED);
+    	m_Parent.sendToClient(new byte[] {0x01, 0x00});
+   }
 
 	public byte[] readByteString() {
 		byte length = getByte();

--- a/src/main/java/org/bbottema/javasocksproxyserver/SocksServer.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/SocksServer.java
@@ -15,10 +15,15 @@ public class SocksServer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SocksServer.class);
 	
 	private volatile boolean stopped = false;
-	private final int listenPort;
+	private int listenPort;
 
-	private final ServerSocketFactory factory;
+	private ServerSocketFactory factory;
 	private Authenticator authenticator = null;
+
+	public SocksServer() {
+		listenPort = 1080;
+		factory = ServerSocketFactory.getDefault();
+	}
 
 	public SocksServer(int listenPort) {
 		this.listenPort = listenPort;
@@ -33,6 +38,18 @@ public class SocksServer {
 	public SocksServer setAuthenticator(Authenticator authenticator) {
 		this.authenticator = authenticator;
 		return this;
+	}
+
+	@Deprecated
+	public synchronized void start(int port) {
+		start(port, ServerSocketFactory.getDefault());
+  }
+
+	@Deprecated
+	public synchronized void start(int port, ServerSocketFactory factory) {
+		listenPort = port;
+		this.factory = factory;
+		start();
 	}
 
 	public synchronized SocksServer start() {

--- a/src/main/java/org/bbottema/javasocksproxyserver/auth/Authenticator.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/auth/Authenticator.java
@@ -1,0 +1,6 @@
+package org.bbottema.javasocksproxyserver.auth;
+
+public abstract class Authenticator {
+  public abstract byte accept(byte[] authTypes);
+  public abstract boolean validate(byte[] username, byte[] password);
+}

--- a/src/main/java/org/bbottema/javasocksproxyserver/auth/DefaultAuthenticator.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/auth/DefaultAuthenticator.java
@@ -1,0 +1,20 @@
+package org.bbottema.javasocksproxyserver.auth;
+
+import org.bbottema.javasocksproxyserver.AuthConstants;
+
+public class DefaultAuthenticator extends Authenticator {
+  @Override
+  public byte accept(byte[] authTypes) {
+    for (byte type : authTypes) {
+      if (type == AuthConstants.TYPE_NO_AUTH) {
+        return type;
+      }
+    }
+    return AuthConstants.NONE_ACCEPTED;
+  }
+
+  @Override
+  public boolean validate(byte[] username, byte[] password) {
+    throw new RuntimeException("Calling validate() on Default Authenticator");
+  }
+}

--- a/src/main/java/org/bbottema/javasocksproxyserver/auth/DefaultAuthenticator.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/auth/DefaultAuthenticator.java
@@ -3,18 +3,18 @@ package org.bbottema.javasocksproxyserver.auth;
 import org.bbottema.javasocksproxyserver.AuthConstants;
 
 public class DefaultAuthenticator extends Authenticator {
-  @Override
-  public byte accept(byte[] authTypes) {
-    for (byte type : authTypes) {
-      if (type == AuthConstants.TYPE_NO_AUTH) {
-        return type;
-      }
+    @Override
+    public byte accept(byte[] authTypes) {
+        for (byte type : authTypes) {
+            if (type == AuthConstants.TYPE_NO_AUTH) {
+                return type;
+            }
+        }
+        return AuthConstants.NONE_ACCEPTED;
     }
-    return AuthConstants.NONE_ACCEPTED;
-  }
 
-  @Override
-  public boolean validate(byte[] username, byte[] password) {
-    throw new RuntimeException("Calling validate() on Default Authenticator");
-  }
+    @Override
+    public boolean validate(byte[] username, byte[] password) {
+        throw new RuntimeException("Calling validate() on Default Authenticator");
+    }
 }

--- a/src/main/java/org/bbottema/javasocksproxyserver/auth/UsernamePasswordAuthenticator.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/auth/UsernamePasswordAuthenticator.java
@@ -4,15 +4,15 @@ import org.bbottema.javasocksproxyserver.AuthConstants;
 
 public abstract class UsernamePasswordAuthenticator extends Authenticator {
 
-    private final boolean acceptNoAuth;
+    private final boolean acceptNoAuthMode;
 
-    public UsernamePasswordAuthenticator(boolean acceptNoAuth) {
-        this.acceptNoAuth = acceptNoAuth;
+    public UsernamePasswordAuthenticator(boolean acceptNoAuthMode) {
+        this.acceptNoAuthMode = acceptNoAuthMode;
     }
 
     @Override
     public byte accept(byte[] authTypes) {
-        if (acceptNoAuth) {
+        if (acceptNoAuthMode) {
             for (byte type : authTypes) {
                 if (type == AuthConstants.TYPE_NO_AUTH) {
                     return type;

--- a/src/main/java/org/bbottema/javasocksproxyserver/auth/UsernamePasswordAuthenticator.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/auth/UsernamePasswordAuthenticator.java
@@ -4,33 +4,33 @@ import org.bbottema.javasocksproxyserver.AuthConstants;
 
 public abstract class UsernamePasswordAuthenticator extends Authenticator {
 
-  private final boolean acceptNoAuth;
+    private final boolean acceptNoAuth;
 
-  public UsernamePasswordAuthenticator(boolean acceptNoAuth) {
-    this.acceptNoAuth = acceptNoAuth;
-  }
+    public UsernamePasswordAuthenticator(boolean acceptNoAuth) {
+        this.acceptNoAuth = acceptNoAuth;
+    }
 
-  @Override
-  public byte accept(byte[] authTypes) {
-    if (acceptNoAuth) {
-      for (byte type : authTypes) {
-        if (type == AuthConstants.TYPE_NO_AUTH) {
-          return type;
+    @Override
+    public byte accept(byte[] authTypes) {
+        if (acceptNoAuth) {
+            for (byte type : authTypes) {
+                if (type == AuthConstants.TYPE_NO_AUTH) {
+                    return type;
+                }
+            }
         }
-      }
+        for (byte type : authTypes) {
+            if (type == AuthConstants.TYPE_USER_PASS_AUTH) {
+                return type;
+            }
+        }
+        return AuthConstants.NONE_ACCEPTED;
     }
-    for (byte type : authTypes) {
-      if (type == AuthConstants.TYPE_USER_PASS_AUTH) {
-        return type;
-      }
+
+    @Override
+    public boolean validate(byte[] username, byte[] password) {
+        return validate(new String(username), new String(password));
     }
-    return AuthConstants.NONE_ACCEPTED;
-  }
 
-  @Override
-  public boolean validate(byte[] username, byte[] password) {
-    return validate(new String(username), new String(password));
-  }
-
-  public abstract boolean validate(String username, String password);
+    public abstract boolean validate(String username, String password);
 }

--- a/src/main/java/org/bbottema/javasocksproxyserver/auth/UsernamePasswordAuthenticator.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/auth/UsernamePasswordAuthenticator.java
@@ -1,0 +1,36 @@
+package org.bbottema.javasocksproxyserver.auth;
+
+import org.bbottema.javasocksproxyserver.AuthConstants;
+
+public abstract class UsernamePasswordAuthenticator extends Authenticator {
+
+  private final boolean acceptNoAuth;
+
+  public UsernamePasswordAuthenticator(boolean acceptNoAuth) {
+    this.acceptNoAuth = acceptNoAuth;
+  }
+
+  @Override
+  public byte accept(byte[] authTypes) {
+    if (acceptNoAuth) {
+      for (byte type : authTypes) {
+        if (type == AuthConstants.TYPE_NO_AUTH) {
+          return type;
+        }
+      }
+    }
+    for (byte type : authTypes) {
+      if (type == AuthConstants.TYPE_USER_PASS_AUTH) {
+        return type;
+      }
+    }
+    return AuthConstants.NONE_ACCEPTED;
+  }
+
+  @Override
+  public boolean validate(byte[] username, byte[] password) {
+    return validate(new String(username), new String(password));
+  }
+
+  public abstract boolean validate(String username, String password);
+}

--- a/src/main/java/org/bbottema/javasocksproxyserver/junit/SockServerExtension.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/junit/SockServerExtension.java
@@ -24,14 +24,14 @@ public class SockServerExtension implements BeforeAllCallback, AfterAllCallback 
     }
 
     public SockServerExtension(@NotNull Integer port, @NotNull ServerSocketFactory serverSocketFactory) {
-        this.socksServer = new SocksServer();
+        this.socksServer = new SocksServer(port, serverSocketFactory);
         this.port = port;
         this.serverSocketFactory = serverSocketFactory;
     }
 
     @Override
     public void beforeAll(ExtensionContext context) {
-        this.socksServer.start(port, serverSocketFactory);
+        this.socksServer.start();
     }
 
     @Override

--- a/src/test/java/demo/ProxyAuthTest.java
+++ b/src/test/java/demo/ProxyAuthTest.java
@@ -1,0 +1,11 @@
+package demo;
+
+import org.bbottema.javasocksproxyserver.SocksServer;
+
+import java.io.IOException;
+
+public class ProxyAuthTest {
+  public static void main(String[] args) throws IOException {
+    new SocksServer().start(10003);
+  }
+}

--- a/src/test/java/demo/ProxyAuthTest.java
+++ b/src/test/java/demo/ProxyAuthTest.java
@@ -6,6 +6,6 @@ import java.io.IOException;
 
 public class ProxyAuthTest {
   public static void main(String[] args) throws IOException {
-    new SocksServer().start(10003);
+    new SocksServer(10003).start();
   }
 }

--- a/src/test/java/demo/StartProxy.java
+++ b/src/test/java/demo/StartProxy.java
@@ -2,6 +2,7 @@ package demo;
 
 import lombok.extern.slf4j.Slf4j;
 import org.bbottema.javasocksproxyserver.SocksServer;
+import org.bbottema.javasocksproxyserver.auth.UsernamePasswordAuthenticator;
 
 import static java.lang.Integer.parseInt;
 
@@ -11,7 +12,13 @@ public class StartProxy {
 	private static final int DEFAULT_PORT = 8888;
 
 	public static void main(String[] args) {
-		new SocksServer().start(determinePort(args));
+		new SocksServer(determinePort(args))
+			.setAuthenticator(new UsernamePasswordAuthenticator(false) {
+				@Override
+				public boolean validate(String username, String password) {
+					return username.equals("mysecureusername") && password.equals("mysecurepassword");
+				}
+			}).start();
 	}
 
 	private static int determinePort(String[] args) {


### PR DESCRIPTION
I've been working on extending auth mode, to support dynamic username/password authentication, with some refactoring.

```java
    new SocksServer(determinePort(args))
        .setAuthenticator(new UsernamePasswordAuthenticator(false) {
          @Override
          public boolean validate(String username, String password) {
            return username.equals("mysecureusername") && password.equals("mysecurepassword");
          }
        }).start();
```

So far it is working good, I've tried with multiple clients.